### PR TITLE
Fix information in pkg-config file

### DIFF
--- a/src/boost_serialization.pc.in
+++ b/src/boost_serialization.pc.in
@@ -7,6 +7,5 @@ Name: @TARGET_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 Requires: @PKGCONFIG_REQUIRES@
-Libs: -L${libdir} -l@TARGET_NAME@ @PKGCONFIG_LIBS@
 Cflags: -I${includedir} @PKGCONFIG_CFLAGS@
 


### PR DESCRIPTION
Building libraries that depend on base-boost_serialization fails on macOS since the library only installs header files but a library name to link to is defined in the pkg-config file.